### PR TITLE
Puppeteer v18

### DIFF
--- a/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
+++ b/x-pack/plugins/reporting/public/lib/reporting_api_client/reporting_api_client.ts
@@ -41,6 +41,7 @@ export interface DiagnoseResponse {
   help: string[];
   success: boolean;
   logs: string;
+  capture: string;
 }
 
 interface IReportingAPI {
@@ -223,6 +224,7 @@ export class ReportingAPIClient implements IReportingAPI {
 
   public verifyBrowser() {
     return this.http.post<DiagnoseResponse>(`${API_BASE_URL}/diagnose/browser`, {
+      // FIXME: asSystemRequest should only be for automatically-triggered requests
       asSystemRequest: true,
     });
   }

--- a/x-pack/plugins/reporting/public/management/components/report_diagnostic.tsx
+++ b/x-pack/plugins/reporting/public/management/components/report_diagnostic.tsx
@@ -127,10 +127,7 @@ export const ReportDiagnostic = ({ apiClient }: Props) => {
           <EuiSpacer />
           <EuiButton
             disabled={isBusy || chromeStatus === 'complete'}
-            onClick={apiWrapper(async () => {
-              const verify = await apiClient.verifyBrowser();
-              return verify;
-            }, statuses.chromeStatus)}
+            onClick={apiWrapper(() => apiClient.verifyBrowser(), statuses.chromeStatus)}
             isLoading={isBusy && chromeStatus === 'incomplete'}
             iconType={chromeStatus === 'complete' ? 'check' : undefined}
           >

--- a/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
+++ b/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
@@ -5,8 +5,13 @@
  * 2.0.
  */
 
+import os from 'os';
 import { schema } from '@kbn/config-schema';
 import type { Logger } from '@kbn/core/server';
+import {
+  getMetrics,
+  Metrics,
+} from '@kbn/screenshotting-plugin/server/browsers/chromium/driver_factory/metrics';
 import { getDefaultChromiumSandboxDisabled } from '@kbn/screenshotting-plugin/server/config/default_chromium_sandbox_disabled';
 import { getChromiumPackage, paths } from '@kbn/screenshotting-plugin/server/utils';
 import { getDataPath } from '@kbn/utils';
@@ -20,167 +25,252 @@ import { authorizedUserPreRouting } from '../lib/authorized_user_pre_routing';
 
 const chromiumPath = path.resolve('x-pack/plugins/screenshotting/chromium');
 const DEFAULT_QUERY_VIEWPORT = '1200,3000,2';
+const queryValidation = {
+  query: schema.maybe(
+    schema.object({
+      viewport: schema.maybe(
+        schema.string({
+          validate: (_input) => {
+            return;
+          },
+        })
+      ),
+    })
+  ),
+};
+const getTime = () => new Date(Date.now()).valueOf();
+const getTiming = ({ start, end }: { start?: number; end?: number }) => {
+  if (end && start) {
+    return end - start;
+  }
+  return null;
+};
+
+interface DiagnoseTimingMetric {
+  start?: number;
+  end?: number;
+}
+interface DiagnoseTimings {
+  launch: DiagnoseTimingMetric;
+  open: DiagnoseTimingMetric;
+  render: DiagnoseTimingMetric;
+  capture: DiagnoseTimingMetric;
+  metrics: DiagnoseTimingMetric;
+  cleanup: DiagnoseTimingMetric;
+}
 
 export const registerDiagnoseScreenshot = (reporting: ReportingCore, loggerContext: Logger) => {
   const logger = loggerContext.get('diagnose-screenshot');
+  const headlessLogger = logger.get('headless-console');
   const setupDeps = reporting.getPluginSetupDeps();
   const { router } = setupDeps;
 
-  router.post<void, { viewport: string } | undefined, void>(
+  router.post<void, { viewport?: string } | undefined, void>(
     {
       path: `${API_DIAGNOSE_URL}/screenshot`,
-      validate: {
-        query: schema.maybe(
-          schema.object({
-            // width,height,deviceScaleFactor
-            // must validate as: `number,number,number`
-            viewport: schema.string({ validate: (input) => input }),
-          })
-        ),
-      },
+      validate: queryValidation,
     },
-    authorizedUserPreRouting(
-      reporting,
-      async (
-        _user,
-        context,
-        req,
-        res
-        // prettier-ignore
-      ) => {
-        if (context.reporting == null) {
-          return res.custom({ statusCode: 503 });
+    authorizedUserPreRouting(reporting, async (_user, context, req, res) => {
+      if (context.reporting == null) {
+        return res.custom({ statusCode: 503 });
+      }
+
+      // width,height,deviceScaleFactor
+      const queryViewport = req.query?.viewport ?? DEFAULT_QUERY_VIEWPORT;
+
+      let browser: puppeteer.Browser | null = null;
+      let page: puppeteer.Page | null = null;
+      let devTools: puppeteer.CDPSession | null = null;
+      let startMetrics: Metrics | null = null;
+      const error$ = new ReplaySubject<Error>();
+      const log$ = new ReplaySubject<string>();
+
+      const timings: DiagnoseTimings = {
+        launch: {},
+        open: {},
+        render: {},
+        capture: {},
+        metrics: {},
+        cleanup: {},
+      };
+
+      const realLog = (message: string, realLogger = logger) => {
+        log$.next(message);
+        realLogger.info(message);
+      };
+
+      try {
+        // 1. Setup
+        const packageInfo = getChromiumPackage();
+        const executablePath = paths.getBinaryPath(packageInfo, chromiumPath);
+        const dataDir = getDataPath();
+        fs.mkdirSync(dataDir, { recursive: true });
+        const userDataDir = fs.mkdtempSync(path.join(dataDir, 'chromium-'));
+        const { os: sandboxOs, disableSandbox } = await getDefaultChromiumSandboxDisabled();
+
+        realLog(`sandbox disabled: ${disableSandbox}`);
+        realLog(`os / distro: ${JSON.stringify(sandboxOs)}`);
+        realLog(`architecture: ${os.arch()}`);
+        realLog(`chromium path: ${chromiumPath}`);
+        realLog(`binary path: ${executablePath}`);
+        realLog(`viewport (width,height,deviceScaleFactor): ${queryViewport}`);
+        realLog(`user data: ${userDataDir}`);
+
+        const args = [
+          `--disable-background-networking`,
+          `--disable-default-apps`,
+          `--disable-extensions`,
+          `--disable-gpu`,
+          `--disable-sync`,
+          `--disable-translate`,
+          `--headless`,
+          `--hide-scrollbars`,
+          `--mainFrameClipsContent=false`,
+          `--metrics-recording-only`,
+          `--mute-audio`,
+          `--no-first-run`,
+          `--safebrowsing-disable-auto-update`,
+          `--user-data-dir=${userDataDir}`,
+          `--window-size=1950,1200`,
+        ];
+        if (disableSandbox) {
+          args.push('--no-sandbox');
         }
 
-        // width,height,deviceScaleFactor
-        const queryViewport = req.query?.viewport ?? DEFAULT_QUERY_VIEWPORT;
+        // 2. Launch
+        timings.launch.start = getTime();
+        browser = await puppeteer.launch({ executablePath, userDataDir, args });
+        page = await browser.newPage();
 
-        let browser: puppeteer.Browser | null = null;
-        let page: puppeteer.Page | null = null;
-        const error$ = new ReplaySubject<Error>();
-        const log$ = new ReplaySubject<string>();
+        // 3. ADD LISTENERS
+        page.on('console', (msg) => {
+          const [text, type] = [msg.text(), msg.type()];
+          realLog(`console-${type}: ${text}`, headlessLogger);
+        });
+        page.on('error', (err) => {
+          headlessLogger.error(err);
+          error$.next(err);
+        });
+
+        // 4. START METRICS, GET VERSION
+        devTools = await page.target().createCDPSession();
+        await devTools.send('Performance.enable', { timeDomain: 'timeTicks' });
+        startMetrics = await devTools.send('Performance.getMetrics');
+
+        const versionInfo = await devTools.send('Browser.getVersion');
+        realLog(`browser version: ${JSON.stringify(versionInfo)}`);
+        timings.launch.end = getTime();
+
+        // 5. GO TO PAGE
+        timings.open.start = getTime();
+        await page.goto('https://webglsamples.org/aquarium/aquarium.html', {
+          waitUntil: 'load',
+        });
+        await page.evaluate(() => {
+          // eslint-disable-next-line no-console
+          console.log(
+            `Navigating URL with viewport size: width=${window.innerWidth} height=${window.innerHeight} scaleFactor:${window.devicePixelRatio}`
+          );
+          window.addEventListener('resize', () => {
+            // eslint-disable-next-line no-console
+            console.log(
+              `Detected a viewport resize: width=${window.innerWidth} height=${window.innerHeight} scaleFactor:${window.devicePixelRatio}`
+            );
+          });
+        });
+        timings.open.end = getTime();
+      } catch (err) {
+        error$.next(err);
+        logger.error(err);
+      }
+
+      const [width, height, deviceScaleFactor] = queryViewport
+        .split(',')
+        .map((part) => parseInt(part, 10));
+      const viewport: puppeteer.Viewport = { width, height, deviceScaleFactor };
+
+      let capture: string | null = null;
+      if (page != null && browser != null) {
+        // 5. INITIAL SIZE
+        timings.render.start = getTime();
+        await page.setViewport(viewport);
+
+        // 6. WAIT FOR RENDER
+        await new Promise((resolve) => setTimeout(resolve, 1000));
 
         try {
-          // SETUP
-          const packageInfo = getChromiumPackage();
-          const executablePath = paths.getBinaryPath(packageInfo, chromiumPath);
-          const dataDir = getDataPath();
-          fs.mkdirSync(dataDir, { recursive: true });
-          const userDataDir = fs.mkdtempSync(path.join(dataDir, 'chromium-'));
-          const { os, disableSandbox } = await getDefaultChromiumSandboxDisabled();
+          // 7. RESIZE BEFORE CAPTURE
+          // rendering may have changed the dimensions we need to capture.
+          // set device scale factor: affects the blurriness / clarity of the numbers
+          await page.setViewport(viewport);
+          timings.render.end = getTime();
 
-          logger.info(`sandbox disabled: ${disableSandbox}`);
-          logger.info(`os / distro: ${JSON.stringify(os)}`);
-          logger.info(`chromium path: ${chromiumPath}`);
-          logger.info(`browser info: ${JSON.stringify(packageInfo)}`);
-          logger.info(`binary path: ${executablePath}`);
-          logger.info(`viewport (width,height,deviceScaleFactor): ${queryViewport}`);
-          logger.info(`user data: ${userDataDir}`);
+          // 8. CAPTURE
+          timings.capture.start = getTime();
+          realLog(`Capturing screenshot...`);
+          const screenshot = await page.screenshot({
+            clip: { x: 0, y: 0, width: viewport.width, height: viewport.height },
+            captureBeyondViewport: false,
+          });
+          timings.capture.end = getTime();
 
-          const args = [
-            `--disable-background-networking`,
-            `--disable-default-apps`,
-            `--disable-extensions`,
-            `--disable-gpu`,
-            `--disable-sync`,
-            `--disable-translate`,
-            `--headless`,
-            `--hide-scrollbars`,
-            `--mainFrameClipsContent=false`,
-            `--metrics-recording-only`,
-            `--mute-audio`,
-            `--no-first-run`,
-            `--safebrowsing-disable-auto-update`,
-            `--user-data-dir=${userDataDir}`,
-            `--window-size=1950,1200`,
-          ];
-          if (disableSandbox) {
-            args.push('--no-sandbox');
+          // 9. REPORT METRICS
+          if (devTools != null && startMetrics != null) {
+            timings.metrics.start = getTime();
+            const endMetrics = await devTools.send('Performance.getMetrics');
+            const metrics = getMetrics(startMetrics, endMetrics);
+            const { cpuInPercentage, memoryInMegabytes } = metrics;
+            realLog(`Chromium consumed CPU ${cpuInPercentage}% Memory ${memoryInMegabytes}MB`);
+            timings.metrics.end = getTime();
           }
 
-          // LAUNCH
-          logger.info(`Launching the browser...`);
-          browser = await puppeteer.launch({ executablePath, userDataDir, args });
-          page = await browser.newPage();
+          // 10. CLEANUP
+          timings.cleanup.start = getTime();
+          realLog(`Closing the browser...`);
+          await browser.close();
 
-          // ADD LISTENERS
-          page.on('console', (msg) => {
-            const [text, type] = [msg.text(), msg.type()];
-            logger.info(`console-${type}: ${text}`);
-            log$.next(`console-${type}: ${text}`);
-          });
-
-          page.on('error', (err) => {
-            logger.error(err);
-            error$.next(err);
-          });
-
-          logger.info(`Navigating to test page...`);
-          await page.goto('https://webglsamples.org/aquarium/aquarium.html', {
-            waitUntil: 'load',
-          });
+          if (Buffer.isBuffer(screenshot)) {
+            realLog(`Preparing the screenshot for response...`);
+            capture = screenshot.toString('base64');
+          } else {
+            capture = screenshot;
+          }
+          timings.cleanup.end = getTime();
         } catch (err) {
-          error$.next(err);
           logger.error(err);
+          error$.next(err);
         }
-
-        const [width, height, deviceScaleFactor] = queryViewport
-          .split(',')
-          .map((part) => parseInt(part, 10));
-        const viewport: puppeteer.Viewport = { width, height, deviceScaleFactor };
-
-        let capture: string | null = null;
-        if (page != null && browser != null) {
-          // FIXME: needs to poll the DOM or scan the console logs to determine when page is ready to capture
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-
-          try {
-            // set device scale factor: affects the blurriness / clarity of the numbers
-            logger.info(`Resizing the window...`);
-            await page.setViewport(viewport);
-
-            // capture the page
-            logger.info(`Capturing screenshot...`);
-            const screenshot = await page.screenshot({
-              clip: { x: 0, y: 0, width: viewport.width, height: viewport.height },
-              captureBeyondViewport: false,
-            });
-
-            logger.info(`Closing the browser...`);
-            await browser.close();
-
-            logger.info(`Preparing the screenshot for response...`);
-            if (Buffer.isBuffer(screenshot)) {
-              capture = screenshot.toString('base64');
-            } else {
-              capture = screenshot;
-            }
-          } catch (err) {
-            logger.error(err);
-            error$.next(err);
-          }
-        }
-
-        let errors: string[] | undefined;
-        let logs: string[] | undefined;
-        error$.pipe(toArray()).subscribe((errs) => {
-          errors = errs.map((e) => e.toString() + '\n');
-        });
-        log$.pipe(toArray()).subscribe((ls) => {
-          logs = ls.map((l) => l + '\n');
-        });
-        error$.complete();
-        log$.complete();
-
-        return res.ok({
-          body: {
-            success: capture != null,
-            help: errors,
-            logs,
-            capture,
-          },
-        });
       }
-    )
+
+      let errors: string[] | undefined;
+      let logs: string[] | undefined;
+      error$.pipe(toArray()).subscribe((errs) => {
+        errors = errs.map((e) => e.toString() + '\n');
+      });
+      log$.pipe(toArray()).subscribe((ls) => {
+        logs = ls.map((l) => l + '\n');
+      });
+
+      realLog(`Done`);
+      error$.complete();
+      log$.complete();
+
+      return res.ok({
+        body: {
+          timings: {
+            launch: getTiming(timings.launch),
+            open: getTiming(timings.open),
+            render: getTiming(timings.render),
+            capture: getTiming(timings.capture),
+            metrics: getTiming(timings.metrics),
+            cleanup: getTiming(timings.cleanup),
+          },
+          success: capture != null,
+          help: errors,
+          logs,
+          capture,
+        },
+      });
+    })
   );
 };

--- a/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
+++ b/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
@@ -24,7 +24,7 @@ import { API_DIAGNOSE_URL } from '../../../common/constants';
 import { authorizedUserPreRouting } from '../lib/authorized_user_pre_routing';
 
 const chromiumPath = path.resolve('x-pack/plugins/screenshotting/chromium');
-const DEFAULT_QUERY_VIEWPORT = '1200,3000,2';
+const DEFAULT_QUERY_VIEWPORT = '2400,2000,2';
 const queryValidation = {
   query: schema.maybe(
     schema.object({

--- a/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
+++ b/x-pack/plugins/reporting/server/routes/diagnostic/screenshot.ts
@@ -132,6 +132,8 @@ export const registerDiagnoseScreenshot = (reporting: ReportingCore, loggerConte
           `--safebrowsing-disable-auto-update`,
           `--user-data-dir=${userDataDir}`,
           `--window-size=1950,1200`,
+          `--enable-logging`,
+          `--v=1`,
         ];
         if (disableSandbox) {
           args.push('--no-sandbox');

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -293,7 +293,7 @@ export class HeadlessChromiumDriverFactory {
    */
   private async getErrorMessage(message: ConsoleMessage): Promise<undefined | string> {
     for (const arg of message.args()) {
-      const errorMessage = await arg.executionContext().evaluate((_arg: unknown) => {
+      const errorMessage = await arg.evaluate((_arg: unknown) => {
         /* !! We are now in the browser context !! */
         if (_arg instanceof Error) {
           return _arg.message;

--- a/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/paths.ts
@@ -57,7 +57,7 @@ export class ChromiumArchivePaths {
       architecture: 'arm64',
       archiveFilename: 'chrome-mac.zip',
       archiveChecksum: '5afc0d49865d55b69ea1ff65b9cc5794',
-      binaryChecksum: '27ab9da01ef5c0a7f03656a88ed189c4',
+      binaryChecksum: '4a7a663b2656d66ce975b00a30df3ab4',
       binaryRelativePath: 'chrome-mac/Chromium.app/Contents/MacOS/Chromium',
       location: 'common',
       archivePath: 'Mac_Arm',

--- a/x-pack/plugins/screenshotting/server/config/default_chromium_sandbox_disabled.ts
+++ b/x-pack/plugins/screenshotting/server/config/default_chromium_sandbox_disabled.ts
@@ -32,6 +32,7 @@ const distroSupportsUnprivilegedUsernamespaces = (distro: string) => {
   return true;
 };
 
+// FIXME: needs to take cpu architecture into account
 interface OsSummary {
   disableSandbox: boolean;
   os: { os: string; dist?: string; release?: string };


### PR DESCRIPTION
## Summary

This PR helps test https://github.com/elastic/kibana/pull/141031 with a change to the diagnostic tool that attempts to capture a webgl test page. You can access this test through Stack Management > Reporting > "Run reporting diagnostics"

<img width="1840" alt="Screen Shot 2022-10-04 at 5 54 25 PM" src="https://user-images.githubusercontent.com/908371/193956505-d56981a0-bd3c-49c5-9993-a729aa64ffb7.png">

You can use curl with the diagnostic route to iterate more quickly in testing. The endpoint allows you to provide window dimensions to test different sizes and deviceScaleFactor:
```
curl 'http://elastic:changeme@localhost:5601/api/reporting/diagnose/screenshot?viewport=800,600,1' \
  -X 'POST' \
  -H 'Content-Type: application/json' \
  -H 'kbn-xsrf: screenshot' | jq '{ timings: .timings, success: .success, help: .help, logs: .logs }'
```
<img width="1348" alt="Screen Shot 2022-10-04 at 5 56 33 PM" src="https://user-images.githubusercontent.com/908371/193956752-2ad9d091-b36c-4d5c-b065-f4422b574305.png">
